### PR TITLE
Signup workflow

### DIFF
--- a/lib/http-users/user/confirm.js
+++ b/lib/http-users/user/confirm.js
@@ -68,6 +68,7 @@ exports.resource = function (app) {
           return callback(err);
         }
 
+        // If the new status is "pending", we need to send an email.
         if (target.status === 'pending' && app.mailer && app.mailer.sendConfirm) {
           return app.mailer.sendConfirm(target, function (err) {
             return err ? callback(err) : callback(null, target);
@@ -86,6 +87,7 @@ exports.resource = function (app) {
       return callback(new Error('Invalid Invite Code'));
     }
     else if ((!username || username === this.username) && creds.inviteCode) {
+      // Attempt to switch the user to "active".
       User.byInviteCode(creds.inviteCode, function (err, users) {
         if (err) {
           return callback(err);

--- a/lib/http-users/user/confirm.js
+++ b/lib/http-users/user/confirm.js
@@ -53,15 +53,15 @@ exports.resource = function (app) {
         'confirm-time': +Date.now()
       };
 
+      if (target.status === 'new' && update.status === 'pending') {
+        update.inviteCode = uuid.v4();
+      }
+
       // resourceful updates don't update the User object (this is a bug).
       // We get around this (for now) by updating them by-hand.
       Object.keys(update).forEach(function (k) {
         target[k] = update[k];
       });
-      
-      if (target.status === 'new' && update.status === 'pending') {
-        update.inviteCode = uuid.v4();
-      }
       
       User.update(target.username, update, function (err, res) {
         if (err) {

--- a/lib/http-users/user/confirm.js
+++ b/lib/http-users/user/confirm.js
@@ -47,6 +47,10 @@ exports.resource = function (app) {
       username = null;
     }
     
+    //
+    // Updates the `status` of the `target` user along with the timestamp
+    // when they were confirmed.
+    //
     function updateStatus(target, status) {
       var update = { 
         status: status || 'pending',
@@ -57,8 +61,10 @@ exports.resource = function (app) {
         update.inviteCode = uuid.v4();
       }
 
-      // resourceful updates don't update the User object (this is a bug).
+      //
+      // `resourceful` updates don't update the User object (this is a bug).
       // We get around this (for now) by updating them by-hand.
+      //
       Object.keys(update).forEach(function (k) {
         target[k] = update[k];
       });
@@ -68,7 +74,9 @@ exports.resource = function (app) {
           return callback(err);
         }
 
+        //
         // If the new status is "pending", we need to send an email.
+        //
         if (target.status === 'pending' && app.mailer && app.mailer.sendConfirm) {
           return app.mailer.sendConfirm(target, function (err) {
             return err ? callback(err) : callback(null, target);
@@ -87,7 +95,12 @@ exports.resource = function (app) {
       return callback(new Error('Invalid Invite Code'));
     }
     else if ((!username || username === this.username) && creds.inviteCode) {
+      //
+      // In order for a user to become active on their own they must provide the invite
+      // code (i.e. confirmation code) for their account to prove that they are human.
+      //
       // Attempt to switch the user to "active".
+      //
       User.byInviteCode(creds.inviteCode, function (err, users) {
         if (err) {
           return callback(err);
@@ -110,16 +123,32 @@ exports.resource = function (app) {
     }
     else if (this.can('modify users')) {
       //
-      // Confirmation by the superuser results in a status of 'pending', and
-      // sends the user an email with further instructions.
+      // Confirmation by the superuser results in the user status being upgraded
+      // by one level.
+      //
+      // * { 'user:require-activation': true }: Unconfirmed users will be in a state of
+      // 'new' so we upgrade them to a status of 'pending'.
+      //
+      // * { 'user:require-activation': false }: Unconfirmed users will be in a state of
+      // 'pending' so we upgrade them to a status of 'active'.
       //
       User.get(username, function (err, user) {
-        return err
-          ? callback(err)
-          : updateStatus(user, 'pending');
+        if (err) {
+          return callback(err);
+        }
+
+        var requireActivation = app.config.get('user:require-activation');
+
+        updateStatus(
+          user,
+          requireActivation ? 'pending' : 'active'
+        );
       });
     }
     else {
+      //
+      // Otherwise, something when wrong so just Error back.
+      //
       return callback(new Error('Invalid Invite Code'));
     }
   };

--- a/lib/http-users/user/core.js
+++ b/lib/http-users/user/core.js
@@ -38,6 +38,7 @@ exports.resource = function (app) {
     this.string('username').sanitize('lower');
     this.string('password-salt');
     this.string('password');
+    this.string('inviteCode');
     this.string('shake');
     this.string('status');
     this.string('email', { format: 'email', required: true });

--- a/lib/http-users/user/core.js
+++ b/lib/http-users/user/core.js
@@ -56,14 +56,13 @@ exports.resource = function (app) {
       if (user._id && !user.username) {
         user.username = user._id.split('/')[1];
       }
-      
-      if (app.config.get('user:require-activation')) {
-        user.status = 'new';
-        user.inviteCode = uuid.v4();
-      }
-      else {
-        user.status = 'active';
-      }
+
+      user.inviteCode = uuid.v4();
+
+      // If we don't require an activation step, go straight to "pending"
+      user.status = app.config.get('user:require-activation')
+        ? 'new'
+        : 'pending';
 
       if (typeof user.password === 'string') {
         user.setPassword(user.password);

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "registry": "http://reg.njitsu.net:5984"
   },
   "scripts": {
-    "test": "vows test/*-test.js test/**/*-test.js --spec --isolate"
+    "test": "vows test/*-test.js test/**/*-test.js test/**/**/*-test.js --spec --isolate"
   },
   "engines": {
     "node": ">= 0.6.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "http://github.com/flatiron/http-users.git"
   },
   "peerDependencies": {
-    "flatiron": "~0.2.1",
+    "flatiron": "~0.2.5",
     "director": "~1.1.0",
     "restful": "~0.2.0"
   },
@@ -28,7 +28,7 @@
     "node_hash": "0.2.x",
     "director": "~1.0.11",
     "director-explorer": "0.0.1",
-    "flatiron": "~0.2.1",
+    "flatiron": "~0.2.5",
     "nano": "*",
     "resourceful": "~0.2.1",
     "restful": "~0.2.0",

--- a/test/fixtures/users.js
+++ b/test/fixtures/users.js
@@ -51,6 +51,7 @@ module.exports = [
     resource: "User",
     username: "testconfirm",
     password: "1234",
+    inviteCode: "must-have-this",
     email: "testconfirm@testing.com",
     status: "new"
   }

--- a/test/macros/index.js
+++ b/test/macros/index.js
@@ -70,7 +70,9 @@ macros.createDb = function (app) {
   };
 };
 
-macros.seedDb = function (app) {
+macros.seedDb = function (app, options) {
+  options = options || { activation: true };
+
   return {
     "Setting up the tests": {
       "seeding the couch database": {
@@ -116,6 +118,10 @@ macros.seedDb = function (app) {
                 user['password-salt'] = user['password-salt'] || common.randomString(16);
                 user.password = user.password || '';
                 user.password = hash.md5(user.password, user['password-salt']);
+
+                if (!options.activation && user.status === 'new') {
+                  user.status = 'pending';
+                }
               });
               
               nano.db.use(name).bulk(

--- a/test/macros/users.js
+++ b/test/macros/users.js
@@ -26,20 +26,24 @@ module.exports = function (suite, app) {
           }, this.callback)
         },
         "should respond with the appropriate object": function (err, user) {
+
+          // Expose it first thing, in case some assertions fail.
+          newuser = user;
+
           assert.isNull(err);
           assert.isObject(user);
           assert.equal(user.email, 'foo@bar.com');
           assert.equal(user.username, 'newuser');
-          
+
           //
           // using default options not require ativation so
           //
-          assert.equal(user.status, 'active');
+          assert.equal(user.status, 'pending');
           assert.isString(user.password);
           assert.isString(user['password-salt']);
           assert.equal(user.password, hash.md5('1234', user['password-salt']));
           assert.isObject(user.permissions);
-          newuser = user;
+
         }
       },
       "the available() method": {

--- a/test/macros/users.js
+++ b/test/macros/users.js
@@ -39,6 +39,7 @@ module.exports = function (suite, app) {
           // using default options not require ativation so
           //
           assert.equal(user.status, 'pending');
+          assert.isString(user.inviteCode);
           assert.isString(user.password);
           assert.isString(user['password-salt']);
           assert.equal(user.password, hash.md5('1234', user['password-salt']));
@@ -105,7 +106,7 @@ module.exports = function (suite, app) {
   }).addBatch({
     "The User resource": {
       topic: function () {
-        app.resources.User.get('user/juan', this.callback);
+        app.resources.User.get('juan', this.callback);
       },
       "with a key": {
         topic: function (user) {

--- a/test/users/confirm/require-activation-test.js
+++ b/test/users/confirm/require-activation-test.js
@@ -1,5 +1,5 @@
 /*
- * users-api-confirm-test.js: Tests for confirmation in the RESTful users API.
+ * require-activation-test.js: Tests for confirmation with `{ 'user:require-activation': true }`.
  *
  * (C) 2010, Nodejitsu Inc.
  *
@@ -7,14 +7,14 @@
 
 var assert = require('assert'),
     apiEasy = require('api-easy'),
-    macros  = require('../macros'),
-    app     = require('../fixtures/app/couchdb');
+    macros  = require('../../macros'),
+    app     = require('../../fixtures/app/couchdb');
     
 var port = 8080;
 
 app.config.set('user:require-activation', true);
 
-apiEasy.describe('http-users/user/api')
+apiEasy.describe('http-users/user/api/confirm/require-activation')
   .addBatch(macros.requireStart(app))
   .addBatch(macros.seedDb(app))
   .use('localhost', port)

--- a/test/users/users-api-confirm-test.js
+++ b/test/users/users-api-confirm-test.js
@@ -12,7 +12,7 @@ var assert = require('assert'),
     
 var port = 8080;
 
-app.config.set('users:require-activation', true);
+app.config.set('user:require-activation', true);
 
 apiEasy.describe('http-users/user/api')
   .addBatch(macros.requireStart(app))
@@ -38,6 +38,7 @@ apiEasy.describe('http-users/user/api')
     .post('/users/daniel/confirm', {})
       .expect(400)
     .next()
+      .authenticate('charlie', '1234')
       .get('/users/daniel')
         .expect(200)
         .expect('user to be still `new`', function (err, res, body) {
@@ -47,6 +48,7 @@ apiEasy.describe('http-users/user/api')
         })
     .undiscuss()
     .next()
+    .authenticate('daniel', '1234')
     .discuss('with invite code')
     .post('/users/daniel/confirm', { inviteCode: 'h4x0r' })
       .expect(200)
@@ -68,11 +70,10 @@ apiEasy.describe('http-users/user/api')
         assert.equal(JSON.parse(body).error, 'Invalid Invite Code');
       })
     .next()
-    .authenticate('testconfirm', '1234')
+    .authenticate('charlie', '1234')
     .get('/users/testconfirm')
       .expect('should not change the user status', function (err, res, body) {
         assert.isNull(err);
-        
         var result = JSON.parse(body);
         assert.isObject(result.user);
         assert.equal(result.user.status, 'new');

--- a/test/users/users-api-test.js
+++ b/test/users/users-api-test.js
@@ -60,6 +60,7 @@ apiEasy.describe('http-users/user/api')
       assert.isObject(result);
       assert.isObject(result.user);
       assert.equal(result.user.username, 'devjitsu');
+      assert.isString(result.user.inviteCode)
     })
   .get('/users/noob')
     .expect(404)
@@ -75,6 +76,7 @@ apiEasy.describe('http-users/user/api')
       assert.isObject(result.user);
       assert.equal(result.user.username, 'devjitsu');
       assert.equal(result.user.email, 'working@test.com');
+      assert.isString(result.user.inviteCode);
     })
   .post('/users/testjitsu', {
     username: 'testjitsu',


### PR DESCRIPTION
These commits should change the behavior of signup processes sans-activation to still require an email-based activation step.
