### PR TITLE
[api] "confirm" as a superuser should bump "new" to "pending" and "pending" to active regardless of "requires-activation" setting

### DIFF
--- a/lib/http-users/user/confirm.js
+++ b/lib/http-users/user/confirm.js
@@ -57,6 +57,9 @@ exports.resource = function (app) {
         'confirm-time': +Date.now()
       };
 
+      // TODO: Is this chunk of code necessary? It looks like a hack to get
+      // around inviteCodes not being set during the create step (which is
+      // now fixed).
       if (target.status === 'new' && update.status === 'pending') {
         update.inviteCode = uuid.v4();
       }
@@ -126,10 +129,10 @@ exports.resource = function (app) {
       // Confirmation by the superuser results in the user status being upgraded
       // by one level.
       //
-      // * { 'user:require-activation': true }: Unconfirmed users will be in a state of
+      // * user.status == 'new': Unconfirmed users will be in a state of
       // 'new' so we upgrade them to a status of 'pending'.
       //
-      // * { 'user:require-activation': false }: Unconfirmed users will be in a state of
+      // * user.status == 'pending': Unconfirmed users will be in a state of
       // 'pending' so we upgrade them to a status of 'active'.
       //
       User.get(username, function (err, user) {
@@ -137,12 +140,9 @@ exports.resource = function (app) {
           return callback(err);
         }
 
-        var requireActivation = app.config.get('user:require-activation');
+        var status = user.status == 'pending' ? 'active' : 'pending';
 
-        updateStatus(
-          user,
-          requireActivation ? 'pending' : 'active'
-        );
+        updateStatus(user, status);
       });
     }
     else {


### PR DESCRIPTION
This way, after turning off the activation step, we can still use the confirm api endpoint to bump "new" users to "pending" state (and send them their confirmation email).
