### PR TITLE
Add ability to turn on/off confirmations

### DIFF
--- a/lib/http-users/user/confirm.js
+++ b/lib/http-users/user/confirm.js
@@ -79,6 +79,7 @@ exports.resource = function (app) {
 
         //
         // If the new status is "pending", we need to send an email.
+        // For other cases, we don't have to send anything.
         //
         if (target.status === 'pending' && app.mailer && app.mailer.sendConfirm) {
           return app.mailer.sendConfirm(target, function (err) {
@@ -140,7 +141,18 @@ exports.resource = function (app) {
           return callback(err);
         }
 
-        var status = user.status == 'pending' ? 'active' : 'pending';
+
+        var requireConfirm = app.config.get('user:require-confirm'),
+            status;
+
+        // If we require confirmations and the user's status is new,
+        // set to "pending". Otherwise, just set to "active".
+        if (requireConfirm && user.status == 'new') {
+          status = 'pending';
+        }
+        else {
+          status = 'active';
+        }
 
         updateStatus(user, status);
       });

--- a/lib/http-users/user/core.js
+++ b/lib/http-users/user/core.js
@@ -60,10 +60,16 @@ exports.resource = function (app) {
 
       user.inviteCode = uuid.v4();
 
-      // If we don't require an activation step, go straight to "pending"
-      user.status = app.config.get('user:require-activation')
-        ? 'new'
-        : 'pending';
+      // If we don't require a confirmation, go straight to "active"
+      if (app.config.get('user:require-confirm')) {
+        // If we don't require an activation step, go straight to "pending"
+        user.status = app.config.get('user:require-activation')
+          ? 'new'
+          : 'pending';
+      }
+      else {
+        user.status = 'active';
+      }
 
       if (typeof user.password === 'string') {
         user.setPassword(user.password);
@@ -87,10 +93,18 @@ exports.resource = function (app) {
     //
     this.after('create', function (err, user, callback) {
       if (!err) {
-        var requireActivation = app.config.get('user:require-activation'),
-            method = requireActivation ? 'sendPending' : 'sendConfirm';
 
-        return app.mailer && app.mailer[method]
+        var requireActivation = app.config.get('user:require-activation'),
+            requireConfirm = app.config.get('user:require-confirm'),
+            method;
+
+        // Note that we don't send emails when we don't require a confirm
+        // or activation.
+        if (requireConfirm) {
+          method = requireActivation ? 'sendPending' : 'sendConfirm';
+        }
+
+        return app.mailer && method && app.mailer[method]
           ? app.mailer[method](user, callback)
           : callback();
       }

--- a/test/macros/users.js
+++ b/test/macros/users.js
@@ -38,7 +38,7 @@ module.exports = function (suite, app) {
           //
           // using default options not require ativation so
           //
-          assert.equal(user.status, 'pending');
+          assert.equal(user.status, 'active');
           assert.isString(user.inviteCode);
           assert.isString(user.password);
           assert.isString(user['password-salt']);

--- a/test/users/confirm/no-activation-test.js
+++ b/test/users/confirm/no-activation-test.js
@@ -1,5 +1,5 @@
 /*
- * no-activation-test.js: Tests for confirmation with `{ 'user:require-activation': false }`.
+ * no-activation-test.js: Tests for confirmation with `{ 'user:require-activation': false, 'user:require-confirm': true }`.
  *
  * (C) 2010, Nodejitsu Inc.
  *
@@ -11,6 +11,8 @@ var assert = require('assert'),
     app     = require('../../fixtures/app/couchdb');
     
 var port = 8080;
+
+app.config.set('user:require-confirm', true);
 
 apiEasy.describe('http-users/user/api/confirm/no-activation')
   .addBatch(macros.requireStart(app))

--- a/test/users/confirm/require-activation-test.js
+++ b/test/users/confirm/require-activation-test.js
@@ -1,5 +1,5 @@
 /*
- * require-activation-test.js: Tests for confirmation with `{ 'user:require-activation': true }`.
+ * require-activation-test.js: Tests for confirmation with `{ 'user:require-activation': true, 'user:require-confirm': true }`.
  *
  * (C) 2010, Nodejitsu Inc.
  *
@@ -13,6 +13,7 @@ var assert = require('assert'),
 var port = 8080;
 
 app.config.set('user:require-activation', true);
+app.config.set('user:require-confirm', true);
 
 apiEasy.describe('http-users/user/api/confirm/require-activation')
   .addBatch(macros.requireStart(app))


### PR DESCRIPTION
This pull request makes confirming accounts optional by checking for `users:require-confirm`, and defaulting to not requiring a confirmation (or, incidentally, an activation). If confirms are off, then created accounts will go straight to active, and any confirms that _do_ happen should set the user straight to active (instead of a potential intermediary state).

Tests are updated so that they pass.
