### PR TITLE
[3rdparty] Adds functionality to manage third party tokens

### DIFF
--- a/lib/http-users.js
+++ b/lib/http-users.js
@@ -63,12 +63,14 @@ httpUsers.attach = function (options) {
   };
 
   //
-  // ### function requireUsernamePasswordAuth()
+  // ### function requireUserPassAuthForWrite()
   //
   // Middleware which ensures that a User is authenticated via username
   // and password
   //
-  app.requireUsernamePasswordAuth = function requireUsernamePasswordAuth() {
+  // This allows get request (read only access)
+  //
+  app.requireUserPassAuthForWrite = function requireUserPassAuthForWrite() {
     var next = arguments[arguments.length - 1],
         user = this.req.user;
 
@@ -77,11 +79,16 @@ httpUsers.attach = function (options) {
     }
 
     //
-    // If you are not using username and password auth
+    // If it is a get, it's ok to use a token
     //
-    if(user.authMethod.method !== "username/password") {
-      return next(new director.http.Forbidden(
-        'Requires username/password authentication'));
+    if(this.req.method !== "GET") {
+      //
+      // If you are not using username and password auth
+      //
+      if(user.authMethod.method !== "username/password") {
+        return next(new director.http.Forbidden(
+          'Requires username/password authentication'));
+      }
     }
 
     //

--- a/lib/http-users.js
+++ b/lib/http-users.js
@@ -56,7 +56,7 @@ httpUsers.attach = function (options) {
       else if (!user) {
         return next(new director.http.Forbidden('Not authorized'));
       }
-
+console.log(user)
       self.req.user = user;
       next();
     });

--- a/lib/http-users.js
+++ b/lib/http-users.js
@@ -56,7 +56,7 @@ httpUsers.attach = function (options) {
       else if (!user) {
         return next(new director.http.Forbidden('Not authorized'));
       }
-console.log(user)
+
       self.req.user = user;
       next();
     });

--- a/lib/http-users.js
+++ b/lib/http-users.js
@@ -63,6 +63,35 @@ httpUsers.attach = function (options) {
   };
 
   //
+  // ### function requireUsernamePasswordAuth()
+  //
+  // Middleware which ensures that a User is authenticated via username
+  // and password
+  //
+  app.requireUsernamePasswordAuth = function requireUsernamePasswordAuth() {
+    var next = arguments[arguments.length - 1],
+        user = this.req.user;
+
+    if(!user) {
+      return next(new director.http.Forbidden('Not authenticated'));
+    }
+
+    //
+    // If you are not using username and password auth
+    //
+    if(user.authMethod.method !== "username/password") {
+      return next(new director.http.Forbidden(
+        'Requires username/password authentication'));
+    }
+
+    //
+    // All systems go!
+    //
+    next();
+  };
+
+
+  //
   // ### function needPermission (perm, value)
   // Middleware which ensures that the User making the
   // request has the `perm` with the specified value.
@@ -77,7 +106,7 @@ httpUsers.attach = function (options) {
       return can === true
         ? next()
         : next(can || new director.http.Forbidden('Forbidden: missing ' + perm));
-    }
+    };
   };
 
   // if (app.config.stores.literal) {

--- a/lib/http-users/auth.js
+++ b/lib/http-users/auth.js
@@ -80,9 +80,11 @@ UserStrategy.prototype.authenticate = function (req, callback) {
         // If the username and password match the provided username 
         // and checksum then authorize the user.
         //
+        user.authMethod = { method: "username/password" };
         callback(null, user);
       } else {
-        var apiTokens = [];
+        var apiTokens = [],
+            tokenValues = {};
 
         //
         // transform `user.apiTokens` into an array
@@ -95,6 +97,10 @@ UserStrategy.prototype.authenticate = function (req, callback) {
         // The names are just to show in the webops interface.
         //
         for (var key in user.apiTokens) {
+          //
+          // A way to find via token what the key was
+          //
+          tokenValues[user.apiTokens[key]] = key;
           apiTokens.push(user.apiTokens[key]);
         }
 
@@ -103,6 +109,14 @@ UserStrategy.prototype.authenticate = function (req, callback) {
         // They can be used as an alternative to a password.
         //
         if(Array.isArray(apiTokens) && apiTokens.indexOf(auth.password) !== -1) {
+          //
+          // Identify that this authentication was via token
+          //
+          user.authMethod = { 
+            method: "token",  
+            id: tokenValues[auth.password]
+          };
+
           //
           // Password is an authorized api token
           //

--- a/lib/http-users/auth.js
+++ b/lib/http-users/auth.js
@@ -80,7 +80,12 @@ UserStrategy.prototype.authenticate = function (req, callback) {
         // If the username and password match the provided username 
         // and checksum then authorize the user.
         //
-        user.authMethod = { method: "username/password" };
+        Object.defineProperty(user, 'authMethod', {
+          value: { method: "username/password" },
+          enumerable: false,
+          configurable: true
+        });
+
         callback(null, user);
       } else {
         var apiTokens = [],
@@ -112,10 +117,14 @@ UserStrategy.prototype.authenticate = function (req, callback) {
           //
           // Identify that this authentication was via token
           //
-          user.authMethod = { 
-            method: "token",  
-            id: tokenValues[auth.password]
-          };
+          Object.defineProperty(user, 'authMethod', {
+            value: {
+              method: "token",
+              id: tokenValues[auth.password]
+            },
+            enumerable: false,
+            configurable: true
+          });
 
           //
           // Password is an authorized api token

--- a/lib/http-users/organization/core.js
+++ b/lib/http-users/organization/core.js
@@ -271,7 +271,7 @@ exports.routes = function (app) {
   // Require authentication for `/organizations`.
   //
   app.router.before('/organizations', app.requireAuth);
-  app.router.before('/organizations', app.requireUsernamePasswordAuth);
+  app.router.before('/organizations', app.requireUserPassAuthForWrite);
 
   //
   // Add all organizations to the req object

--- a/lib/http-users/organization/core.js
+++ b/lib/http-users/organization/core.js
@@ -271,6 +271,7 @@ exports.routes = function (app) {
   // Require authentication for `/organizations`.
   //
   app.router.before('/organizations', app.requireAuth);
+  app.router.before('/organizations', app.requireUsernamePasswordAuth);
 
   //
   // Add all organizations to the req object

--- a/lib/http-users/user/core.js
+++ b/lib/http-users/user/core.js
@@ -43,7 +43,6 @@ exports.resource = function (app) {
     this.string('status');
     this.string('email', { format: 'email', required: true });
     this.object('profile');
-    this.object('authMethod');
     this.object('tokens');
 
     this.timestamps();

--- a/lib/http-users/user/core.js
+++ b/lib/http-users/user/core.js
@@ -43,7 +43,7 @@ exports.resource = function (app) {
     this.string('status');
     this.string('email', { format: 'email', required: true });
     this.object('profile');
-    this.object('vendorTokens');
+    this.array('thirdPartyTokens');
 
     this.timestamps();
 
@@ -179,13 +179,13 @@ exports.resource = function (app) {
   User._restricted = function (user) {
     var restricted = user.toJSON(),
         apiTokens = restricted.apiTokens || {},
-        vendorTokens = restricted.vendorTokens || {};
+        thirdPartyTokens = restricted.thirdPartyTokens || {};
 
     //
     // Remove actual tokens and leave only the names
     //
     restricted.apiTokens = Object.keys(apiTokens) || [];
-    restricted.vendorTokens = Object.keys(vendorTokens) || [];
+    restricted.thirdPartyTokens = Object.keys(thirdPartyTokens) || [];
 
     //
     // Delete password stuff

--- a/lib/http-users/user/core.js
+++ b/lib/http-users/user/core.js
@@ -207,6 +207,7 @@ exports.routes = function (app) {
   //
   app.router.before('/auth', app.requireAuth);
   app.router.before('/users', app.requireAuth);
+  app.router.before('/users', app.requireUsernamePasswordAuth);
 
   //
   // Only allow users to access `/users/*` routes if they are modifying
@@ -271,25 +272,8 @@ exports.routes = function (app) {
   //
   app.router.before('/users/:username', function (username) {
     var next = arguments[arguments.length - 1],
-        self = this,
-        isATokReq = new RegExp("\\/users\\/" + username + "\\/tokens[\\/]?");
+        self = this;
 
-    //
-    // If it's not a request to modify/access tokens
-    // and we are authenticated (which we should be)
-    //
-    if(!isATokReq.test(self.req.url)) {
-      var currentUser = self.req.user;
-
-      //
-      // Can only change user using username and password
-      // Not tokens
-      //
-      if(currentUser.authMethod.method !== "username/password") {
-        return next(new director.http.Forbidden(
-          'Not authorized to access user with a token'));
-      }
-    }
 
     if (self.req.method === 'PUT' && self.req.body && self.req.body.password) {
       self.req.body.password = hash.md5(

--- a/lib/http-users/user/core.js
+++ b/lib/http-users/user/core.js
@@ -43,7 +43,7 @@ exports.resource = function (app) {
     this.string('status');
     this.string('email', { format: 'email', required: true });
     this.object('profile');
-    this.object('tokens');
+    this.object('vendorTokens');
 
     this.timestamps();
 

--- a/lib/http-users/user/core.js
+++ b/lib/http-users/user/core.js
@@ -178,9 +178,26 @@ exports.resource = function (app) {
   // Returns a restricted representation of the specified `user`.
   //
   User._restricted = function (user) {
-    var restricted = user.toJSON();
+    var restricted = user.toJSON(),
+        apiTokens = restricted.apiTokens || {},
+        vendorTokens = restricted.vendorTokens || {};
+
+    //
+    // Remove actual tokens and leave only the names
+    //
+    restricted.apiTokens = Object.keys(apiTokens) || [];
+    restricted.vendorTokens = Object.keys(vendorTokens) || [];
+
+    //
+    // Delete password stuff
+    //
     delete restricted.password;
     delete restricted['password-salt'];
+
+    //
+    // Eduardo: +351 912372358
+    //
+
     return restricted;
   };
 
@@ -208,7 +225,7 @@ exports.routes = function (app) {
   //
   app.router.before('/auth', app.requireAuth);
   app.router.before('/users', app.requireAuth);
-  app.router.before('/users', app.requireUsernamePasswordAuth);
+  app.router.before('/users', app.requireUserPassAuthForWrite);
 
   //
   // Only allow users to access `/users/*` routes if they are modifying
@@ -265,7 +282,24 @@ exports.routes = function (app) {
   // This routes not need any especial permission for be accesed
   //
   app.router.get('/users/me', function () {
-    return this.res.json(200, { user: this.req.user });
+    return this.res.json(200, { 
+      user: app.resources.User._restricted(this.req.user) });
+  });
+
+  //
+  // Route to try to get a user by username
+  //
+  // Strips confidential fields that should not be accessible via api
+  //
+  app.router.get('/users/:username', function (username) {
+    var res = this.res;
+
+    app.resources.User.get(username, function (err, user) {
+      return err
+        ? res.json(err.status || 500, err)
+        : res.json(200, { 
+          user: app.resources.User._restricted(user) });
+    });
   });
 
   //

--- a/lib/http-users/user/core.js
+++ b/lib/http-users/user/core.js
@@ -274,7 +274,6 @@ exports.routes = function (app) {
     var next = arguments[arguments.length - 1],
         self = this;
 
-
     if (self.req.method === 'PUT' && self.req.body && self.req.body.password) {
       self.req.body.password = hash.md5(
         self.req.body.password,

--- a/lib/http-users/user/core.js
+++ b/lib/http-users/user/core.js
@@ -176,7 +176,7 @@ exports.resource = function (app) {
   // #### @user {User} User object to convert to a restricted representation.
   // Returns a restricted representation of the specified `user`.
   //
-  User._restricted = function (user) {
+  User._restricted = function (user, authType) {
     var restricted = user.toJSON(),
         apiTokens = restricted.apiTokens || {},
         thirdPartyTokens = restricted.thirdPartyTokens || {};
@@ -184,18 +184,16 @@ exports.resource = function (app) {
     //
     // Remove actual tokens and leave only the names
     //
-    restricted.apiTokens = Object.keys(apiTokens) || [];
-    restricted.thirdPartyTokens = Object.keys(thirdPartyTokens) || [];
+    if (authType !== "username/password") {
+      restricted.apiTokens = Object.keys(apiTokens) || [];
+      restricted.thirdPartyTokens = Object.keys(thirdPartyTokens) || [];
+    }
 
     //
     // Delete password stuff
     //
     delete restricted.password;
     delete restricted['password-salt'];
-
-    //
-    // Eduardo: +351 912372358
-    //
 
     return restricted;
   };
@@ -281,8 +279,11 @@ exports.routes = function (app) {
   // This routes not need any especial permission for be accesed
   //
   app.router.get('/users/me', function () {
+    var user  = this.req.user,
+        authMethod = this.req.user.authMethod;
+
     return this.res.json(200, { 
-      user: app.resources.User._restricted(this.req.user) });
+      user: app.resources.User._restricted(user, authMethod) });
   });
 
   //
@@ -291,13 +292,14 @@ exports.routes = function (app) {
   // Strips confidential fields that should not be accessible via api
   //
   app.router.get('/users/:username', function (username) {
-    var res = this.res;
+    var res  = this.res,
+        authMethod = this.req.user.authMethod;
 
     app.resources.User.get(username, function (err, user) {
       return err
         ? res.json(err.status || 500, err)
         : res.json(200, { 
-          user: app.resources.User._restricted(user) });
+          user: app.resources.User._restricted(user, authMethod) });
     });
   });
 

--- a/lib/http-users/user/core.js
+++ b/lib/http-users/user/core.js
@@ -184,7 +184,7 @@ exports.resource = function (app) {
     //
     // Remove actual tokens and leave only the names
     //
-    if (authType !== "username/password") {
+    if (authType && authType.method !== "username/password") {
       restricted.apiTokens = Object.keys(apiTokens) || [];
       restricted.thirdPartyTokens = Object.keys(thirdPartyTokens) || [];
     }

--- a/lib/http-users/user/core.js
+++ b/lib/http-users/user/core.js
@@ -278,15 +278,16 @@ exports.routes = function (app) {
     // If it's not a request to modify/access tokens
     // and we are authenticated (which we should be)
     //
-    if(!isATokReq.test(self.req.url) && self.req.user) {
+    if(!isATokReq.test(self.req.url)) {
       var currentUser = self.req.user;
+
       //
       // Can only change user using username and password
       // Not tokens
       //
       if(currentUser.authMethod.method !== "username/password") {
         return next(new director.http.Forbidden(
-          'Not authorized to access user with token'));
+          'Not authorized to access user with a token'));
       }
     }
 

--- a/lib/http-users/user/core.js
+++ b/lib/http-users/user/core.js
@@ -44,6 +44,7 @@ exports.resource = function (app) {
     this.string('email', { format: 'email', required: true });
     this.object('profile');
     this.object('authMethod');
+    this.object('tokens');
 
     this.timestamps();
 

--- a/lib/http-users/user/core.js
+++ b/lib/http-users/user/core.js
@@ -43,6 +43,7 @@ exports.resource = function (app) {
     this.string('status');
     this.string('email', { format: 'email', required: true });
     this.object('profile');
+    this.object('authMethod');
 
     this.timestamps();
 
@@ -271,7 +272,7 @@ exports.routes = function (app) {
   app.router.before('/users/:username', function (username) {
     var next = arguments[arguments.length - 1],
         self = this;
-
+    console.error(arguments, this)
     if (self.req.method === 'PUT' && self.req.body && self.req.body.password) {
       self.req.body.password = hash.md5(
         self.req.body.password,

--- a/lib/http-users/user/core.js
+++ b/lib/http-users/user/core.js
@@ -271,8 +271,25 @@ exports.routes = function (app) {
   //
   app.router.before('/users/:username', function (username) {
     var next = arguments[arguments.length - 1],
-        self = this;
-    console.error(arguments, this)
+        self = this,
+        isATokReq = new RegExp("\\/users\\/" + username + "\\/tokens[\\/]?");
+
+    //
+    // If it's not a request to modify/access tokens
+    // and we are authenticated (which we should be)
+    //
+    if(!isATokReq.test(self.req.url) && self.req.user) {
+      var currentUser = self.req.user;
+      //
+      // Can only change user using username and password
+      // Not tokens
+      //
+      if(currentUser.authMethod.method !== "username/password") {
+        return next(new director.http.Forbidden(
+          'Not authorized to access user with token'));
+      }
+    }
+
     if (self.req.method === 'PUT' && self.req.body && self.req.body.password) {
       self.req.body.password = hash.md5(
         self.req.body.password,

--- a/lib/http-users/user/index.js
+++ b/lib/http-users/user/index.js
@@ -31,7 +31,8 @@ module.exports = function (app) {
   // Attach optional functionality unless explicitly 
   // asked not to do so.
   //
-  ['confirm', 'keys', 'search', 'tokens'].forEach(function (feature) {
+  ['confirm', 'keys', 'search', 'tokens', 'thirdParty'].forEach(
+  function (feature) {
     var mod = require('./' + feature);
 
     if (options[feature] !== false) {

--- a/lib/http-users/user/index.js
+++ b/lib/http-users/user/index.js
@@ -31,7 +31,7 @@ module.exports = function (app) {
   // Attach optional functionality unless explicitly 
   // asked not to do so.
   //
-  ['confirm', 'keys', 'search', 'tokens', 'thirdParty'].forEach(
+  ['confirm', 'keys', 'search', 'tokens', 'third-party'].forEach(
   function (feature) {
     var mod = require('./' + feature);
 

--- a/lib/http-users/user/third-party.js
+++ b/lib/http-users/user/third-party.js
@@ -221,7 +221,7 @@ exports.routes = function (app) {
   //
   // Setup RESTful web service for `/users/:username/thirdParty`
   //
-  app.router.path('/users/:username/thirdParty', function () {
+  app.router.path('/users/:username/thirdparty', function () {
     //
     // List Tokens: GET to `/users/:username/thirdParty` returns list
     //              of external tokens for the user.

--- a/lib/http-users/user/third-party.js
+++ b/lib/http-users/user/third-party.js
@@ -262,6 +262,10 @@ exports.routes = function (app) {
       }
 
       var res = this.res,
+          //
+          // So people can filter by provider
+          //
+          params = this.req.query,
           authMethod = this.req.user.authMethod;
 
       //
@@ -292,6 +296,17 @@ exports.routes = function (app) {
           //
           return token.app === "*" || (appId && token.app === appId);
         });
+
+        //
+        // Filter by provider
+        //
+        // ?provider=github
+        //
+        if(typeof params.provider === "string") {
+          filteredTokens = filteredTokens.filter(function (token) {
+            return token.provider === params.provider;
+          });
+        }
 
         return res.json(200, filteredTokens);
       });

--- a/lib/http-users/user/third-party.js
+++ b/lib/http-users/user/third-party.js
@@ -185,6 +185,14 @@ exports.resource = function (app) {
     }
 
     //
+    // Dates date object
+    //
+    options.token.timestamps = {
+      last_modified: (new Date()).toString(),
+      epoch: Date.now()
+    };
+
+    //
     // Fetch the existing tokens and add the new one.
     // If tokens did not exist before create them
     //

--- a/lib/http-users/user/third-party.js
+++ b/lib/http-users/user/third-party.js
@@ -334,6 +334,10 @@ exports.routes = function (app) {
           body = this.req.body,
           options = {};
 
+      if(!body) {
+        return res.json(400, new Error("You need to provide an body"));
+      }
+
       //
       // The three things people can set up
       //

--- a/lib/http-users/user/third-party.js
+++ b/lib/http-users/user/third-party.js
@@ -1,0 +1,298 @@
+/*
+ * third-party.js: Resource extensions and routes for working with 
+ * external providor tokens
+ *
+ * E.g. Storing a github token that allows us access to github from this user
+ *
+ * (C) 2012, Nodejitsu Inc.
+ *
+ */
+
+var uuid = require('node-uuid'),
+    async = require('flatiron').common.async;
+
+//
+// ### function resource (app)
+// #### @app {flatiron.App} Application to extend User resource
+//
+// Extends the User resource for the `app` with functionality working
+// with third party auth tokens.
+//
+exports.resource = function (app) {
+
+  //
+  // Grab the `User` resource from the `app`.
+  //
+  var User = app.resources.User;
+  
+  //
+  // ### function thirdPartyTokens (username, callback)
+  // #### @callback {function} Continuation to respond to when complete.
+  //
+  // Returns all third party tokens for the specified `user`.
+  //
+  User.thirdPartyTokens = function (username, callback) {
+    User.get(username, function (err, user) {
+      if (err) {
+        return callback(err);
+      }
+
+      var thirdPartyTokens = user.thirdPartyTokens || [];
+
+      callback(null, {thirdPartyTokens: thirdPartyTokens});
+    });
+  };
+
+  //
+  // ### function deleteThirdPartyToken (name, data, callback)
+  // #### @username  {string} Name of the user to update
+  // #### @id        {string} Id of the token to delete.
+  // #### @callback  {function} Continuation to respond to when complete.
+  //
+  // Delete a third party API token
+  //
+  User.deleteThirdPartyToken = function (username, id, callback) {
+    //
+    // Fetch the user so we can check for the token
+    //
+    User.get(username, function (err, user) {
+      if (err) {
+        return callback(err);
+      }
+
+      var thirdPartyTokens = user.thirdPartyTokens || [],
+          tokenForId;
+
+      //
+      // Check each token for that id
+      //
+      for(var i in thirdPartyTokens) {
+        if(thirdPartyTokens[i].id === id) {
+          tokenForId = t;
+          break;
+        }
+      }
+
+      if(!tokenForId) {
+        return callback(new Error("Can't delete token, it does not exist"));
+      }
+
+      //
+      // Actually remove the token
+      //
+      thirdPartyTokens.splice(i, 1);
+
+      //
+      // Update the user document with the new `thirdPartyTokens`
+      // We have now removed the `id` token
+      //
+      User.update(username, { thirdPartyTokens: thirdPartyTokens },
+      function (err) {
+        if (err) {
+          return callback(err);
+        }
+
+        //
+        // All done,
+        // return the token that was removed from us
+        //
+        callback(null, tokenForId);
+      });
+    });
+  };
+
+  //
+  // ### function addThirdPartyToken (username, tokenname, callback)
+  // #### @username  {string} Name of the user to update
+  // #### @options   {string} **Optional** Id and app.
+  // #### @callback  {function} Continuation to respond to when complete.
+  //
+  // Adds/Updates an third party API Token
+  //
+  User.addThirdPartyToken = function (username, options, callback) {
+    if (typeof options === "function") {
+      callback = options;
+      options = {};
+    }
+
+    //
+    // Id is required
+    // So create it if it doesnt exit
+    //
+    if(!options.id) {
+      options.id = uuid.v4();
+    }
+
+    //
+    // App is required
+    // Defaults to `*`, meaning any app can use this token
+    //
+    if(!options.app) {
+      options.app = "*"; // Any will do
+    }
+
+    //
+    // The actual token
+    //
+    // Normally something like:
+    //
+    // {
+    //   provider: "github",
+    //   token: "WATWAT",
+    //   app: "fantasticapp", // or *
+    //   info: { ... } // whatever they gave us back
+    // }
+    //
+    if(!options.token) {
+      return callback(new Error("No token was provided."));
+    }
+
+    //
+    // Add them to object
+    // Override if it must; consolidate.
+    //
+    options.token.id = options.id;
+    options.token.app = options.app;
+
+    //
+    // Fetch the existing tokens and add the new one.
+    // If tokens did not exist before create them
+    //
+    User.get(username, function (err, user) {
+      if (err) {
+        return callback(err);
+      }
+
+      //
+      // Get our tokens
+      //
+      var thirdPartyTokens = user.thirdPartyTokens || [],
+          selectedToken;
+
+      //
+      // Is this an update?
+      // Give the problem back to the user if it fails
+      //
+      for(var i in thirdPartyTokens) {
+        if(thirdPartyTokens[i].id === options.id) {
+          selectedToken = options.token;
+          break;
+        }
+      }
+
+      //
+      // Is this an update or insert?
+      //
+      if(selectedToken) {
+        options.token.operation = "update";
+        thirdPartyTokens[i] = options.token;
+      } else {
+        options.token.operation = "insert";
+        thirdPartyTokens.push(options.token);
+      }
+
+      //
+      // Update the user document with the new `thirdPartyTokens`
+      //
+      User.update(username, { thirdPartyTokens: thirdPartyTokens },
+      function (err) {
+        if (err) {
+          return callback(err);
+        }
+
+        //
+        // Return the token to the client, case he needs info
+        // like auto generated id
+        //
+        callback(null, options.token);
+      });
+    });
+  };
+};
+
+//
+// ### function routes (app)
+// #### @app {flatiron.App} Application to extend with routes
+//
+// Extends the target `app` with routes for working with third party
+// tokens.
+//
+exports.routes = function (app) {
+  //
+  // Setup RESTful web service for `/users/:username/thirdParty`
+  //
+  app.router.path('/users/:username/thirdParty', function () {
+    //
+    // List Tokens: GET to `/users/:username/thirdParty` returns list
+    //              of external tokens for the user.
+    //
+    this.get(function listThirdPartyTokens(username) {
+      var res = this.res,
+          authMethod = this.req.user.authMethod;
+
+      app.resources.User.thirdPartyTokens(username, function (err, tokens) {
+        //
+        // If you are not using username and password auth
+        //
+        if(authMethod.method !== "username/password") {
+          //
+          // Return nothing
+          //
+          return res.json(403, new Error("Not authorized to list 3rd party" +
+            " tokens unless you authenticate with username and password"));
+        }
+
+        return err
+          ? res.json(500, err)
+          : res.json(200, tokens);
+      });
+    });
+
+    //
+    // DELETE /users/:userid/thirdParty/:id
+    //
+    this.delete('/:id', function deleteThirdPartyToken(username, id, cb) {
+      var res = this.res;
+
+      app.resources.User.deleteThirdPartyToken(username, tokenname,
+      function (err, deleted) {
+        return err 
+             ? res.json(500, err)
+             : res.json(201, { ok: true, id: id, deleted: deleted });
+      });
+    });
+
+    //
+    // Add / Update Token: POST to `/users/:username/thirdParty/:id` 
+    // adds/modified a new token to the 3rd party token array.
+    //
+    function addOrUpdateThirdPartyToken(username, id, callback) {
+      var res = this.res,
+          body = this.req.body,
+          options = {};
+
+      //
+      // The three things people can set up
+      //
+      options.id    = id       || body.id    || body.token && body.token.id;
+      options.app   = body.app || body.token && body.token.app;
+      options.token = body.token;
+
+      app.resources.User.addThirdPartyToken(username, options,
+      function (err, newToken) {
+        return err ? res.json(500, err) : res.json(201, newToken);
+      });
+
+    }
+
+    //
+    // POST /users/:userid/thirdParty/:id
+    //
+    this.put('/:id', addOrUpdateThirdPartyToken);
+
+    //
+    // POST /users/:userid/thirdParty
+    //
+    this.post(addOrUpdateThirdPartyToken);
+  });
+};

--- a/lib/http-users/user/third-party.js
+++ b/lib/http-users/user/third-party.js
@@ -68,7 +68,7 @@ exports.resource = function (app) {
       //
       for(var i in thirdPartyTokens) {
         if(thirdPartyTokens[i].id === id) {
-          tokenForId = t;
+          tokenForId = thirdPartyTokens[i];
           break;
         }
       }
@@ -91,6 +91,12 @@ exports.resource = function (app) {
         if (err) {
           return callback(err);
         }
+
+        //
+        // Try not to confuse our users
+        // This would be the previous operation, which is strange
+        //
+        tokenForId.operation = "delete";
 
         //
         // All done,
@@ -116,22 +122,6 @@ exports.resource = function (app) {
     }
 
     //
-    // Id is required
-    // So create it if it doesnt exit
-    //
-    if(!options.id) {
-      options.id = uuid.v4();
-    }
-
-    //
-    // App is required
-    // Defaults to `*`, meaning any app can use this token
-    //
-    if(!options.app) {
-      options.app = "*"; // Any will do
-    }
-
-    //
     // The actual token
     //
     // Normally something like:
@@ -148,11 +138,51 @@ exports.resource = function (app) {
     }
 
     //
+    // Check for provider, its mandatory
+    //
+    if(!options.token.provider) {
+      return callback(new Error("No token provider in the object."));
+    }
+
+    //
+    // Check for token, its mandatory
+    //
+    if(!options.token.token) {
+      return callback(new Error(
+        "No provider token was provided in the object."));
+    }
+
+    //
     // Add them to object
     // Override if it must; consolidate.
     //
-    options.token.id = options.id;
-    options.token.app = options.app;
+    // Thing declared uppermost wins
+    // If not value on token wins
+    // If nothing, we use the sensible defaults defined on lines below
+    //
+    // `options.token` has all the important information,
+    // check for `options.token.id` not `options.id`
+    //
+    // Like, seriously.
+    //
+    options.token.id = options.id || options.token.id;
+    options.token.app = options.app || options.token.app;
+
+    //
+    // Id is required
+    // So create it if it doesnt exit
+    //
+    if(!options.token.id) {
+      options.token.id = uuid.v4();
+    }
+
+    //
+    // App is required
+    // Defaults to `*`, meaning any app can use this token
+    //
+    if(!options.token.app) {
+      options.token.app = "*"; // Any will do
+    }
 
     //
     // Fetch the existing tokens and add the new one.
@@ -174,7 +204,7 @@ exports.resource = function (app) {
       // Give the problem back to the user if it fails
       //
       for(var i in thirdPartyTokens) {
-        if(thirdPartyTokens[i].id === options.id) {
+        if(thirdPartyTokens[i].id === options.token.id) {
           selectedToken = options.token;
           break;
         }
@@ -221,32 +251,63 @@ exports.routes = function (app) {
   //
   // Setup RESTful web service for `/users/:username/thirdParty`
   //
+  // This only returns tokens that can be used accross different applications
+  // This means where app === "*"
+  //
   app.router.path('/users/:username/thirdparty', function () {
+    function listThirdPartyTokens(username, appId, cb) {
+      if (typeof appId === "function") {
+        cb = appId;
+        appId = null;
+      }
+
+      var res = this.res,
+          authMethod = this.req.user.authMethod;
+
+      //
+      // If you are not using username and password auth
+      //
+      if(authMethod.method !== "username/password") {
+        //
+        // Fuck off
+        //
+        return res.json(403, new Error("Not authorized to list 3rd party" +
+          " tokens unless you authenticate with username and password"));
+      }
+
+      app.resources.User.thirdPartyTokens(username, function (err, tokens) {
+        //
+        // Return if there is an error
+        //
+        if(err) {
+          return res.json(500, err);
+        }
+
+        //
+        // Lets collect only the ones that apply to all applications
+        //
+        var filteredTokens = tokens.thirdPartyTokens.filter(function (token) {
+          //
+          // Wildcarded or matches the currently requested app
+          //
+          return token.app === "*" || (appId && token.app === appId);
+        });
+
+        return res.json(200, filteredTokens);
+      });
+    }
+
     //
     // List Tokens: GET to `/users/:username/thirdParty` returns list
     //              of external tokens for the user.
     //
-    this.get(function listThirdPartyTokens(username) {
-      var res = this.res,
-          authMethod = this.req.user.authMethod;
+    this.get(listThirdPartyTokens);
 
-      app.resources.User.thirdPartyTokens(username, function (err, tokens) {
-        //
-        // If you are not using username and password auth
-        //
-        if(authMethod.method !== "username/password") {
-          //
-          // Return nothing
-          //
-          return res.json(403, new Error("Not authorized to list 3rd party" +
-            " tokens unless you authenticate with username and password"));
-        }
-
-        return err
-          ? res.json(500, err)
-          : res.json(200, tokens);
-      });
-    });
+    //
+    // List Tokens: GET to `/users/:username/thirdParty/app/:app` returns list
+    //              of external tokens for the user
+    //
+    this.get('/app/:app', listThirdPartyTokens);
 
     //
     // DELETE /users/:userid/thirdParty/:id
@@ -254,7 +315,7 @@ exports.routes = function (app) {
     this.delete('/:id', function deleteThirdPartyToken(username, id, cb) {
       var res = this.res;
 
-      app.resources.User.deleteThirdPartyToken(username, tokenname,
+      app.resources.User.deleteThirdPartyToken(username, id,
       function (err, deleted) {
         return err 
              ? res.json(500, err)
@@ -263,10 +324,12 @@ exports.routes = function (app) {
     });
 
     //
+    // POST /users/:userid/thirdParty
+    //
     // Add / Update Token: POST to `/users/:username/thirdParty/:id` 
     // adds/modified a new token to the 3rd party token array.
     //
-    function addOrUpdateThirdPartyToken(username, callback) {
+    this.post(function addOrUpdateThirdPartyToken(username, callback) {
       var res = this.res,
           body = this.req.body,
           options = {};
@@ -283,11 +346,6 @@ exports.routes = function (app) {
         return err ? res.json(500, err) : res.json(201, newToken);
       });
 
-    }
-
-    //
-    // POST /users/:userid/thirdParty
-    //
-    this.post(addOrUpdateThirdPartyToken);
+    });
   });
 };

--- a/lib/http-users/user/third-party.js
+++ b/lib/http-users/user/third-party.js
@@ -266,7 +266,7 @@ exports.routes = function (app) {
     // Add / Update Token: POST to `/users/:username/thirdParty/:id` 
     // adds/modified a new token to the 3rd party token array.
     //
-    function addOrUpdateThirdPartyToken(username, id, callback) {
+    function addOrUpdateThirdPartyToken(username, callback) {
       var res = this.res,
           body = this.req.body,
           options = {};
@@ -274,7 +274,7 @@ exports.routes = function (app) {
       //
       // The three things people can set up
       //
-      options.id    = id       || body.id    || body.token && body.token.id;
+      options.id    = body.id  || body.token && body.token.id;
       options.app   = body.app || body.token && body.token.app;
       options.token = body.token;
 
@@ -284,11 +284,6 @@ exports.routes = function (app) {
       });
 
     }
-
-    //
-    // POST /users/:userid/thirdParty/:id
-    //
-    this.put('/:id', addOrUpdateThirdPartyToken);
 
     //
     // POST /users/:userid/thirdParty

--- a/lib/http-users/user/third-party.js
+++ b/lib/http-users/user/third-party.js
@@ -218,7 +218,7 @@ exports.resource = function (app) {
         thirdPartyTokens[i] = options.token;
       } else {
         options.token.operation = "insert";
-        thirdPartyTokens.push(options.token);
+        thirdPartyTokens.unshift(options.token);
       }
 
       //

--- a/lib/http-users/user/tokens.js
+++ b/lib/http-users/user/tokens.js
@@ -34,9 +34,6 @@ exports.resource = function (app) {
         return callback(err);
       }
 
-      //
-      // Update the instance
-      //
       var apiTokens = user.apiTokens || {};
 
       callback(null, {apiTokens: apiTokens});
@@ -188,15 +185,32 @@ exports.routes = function (app) {
     //
     this.get(function (username) {
       var res = this.res,
-          self = this;
+          authMethod = this.req.user.authMethod;
 
       app.resources.User.tokens(username, function (err, tokens) {
+        //
+        // If you are not using username and password auth
+        //
+        if(authMethod.method !== "username/password") {
+          //
+          // Only return the token you used to authenticate
+          //
+          var filteredTokens = {apiTokens: {}},
+              idFromAuth = authMethod.id;
+
+          filteredTokens.apiTokens[idFromAuth] = tokens.apiTokens[idFromAuth];
+
+          //
+          // Return only the current token
+          //
+          return res.json(200, filteredTokens);
+        }
+
         return err
           ? res.json(500, err)
           : res.json(200, tokens);
       });
     });
-
 
     //
     // DELETE /users/:userid/tokens/:tokenname

--- a/lib/http-users/user/tokens.js
+++ b/lib/http-users/user/tokens.js
@@ -191,23 +191,6 @@ exports.routes = function (app) {
           self = this;
 
       app.resources.User.tokens(username, function (err, tokens) {
-        var authMethod = self.req.user.authMethod;
-
-        //
-        // If you are not using username and password auth
-        //
-        if(authMethod.method !== "username/password") {
-          //
-          // Only return the token you used to authenticate
-          //
-          var filteredTokens = {apiTokens: {}},
-              idFromAuth = authMethod.id;
-
-          filteredTokens.apiTokens[idFromAuth] = tokens.apiTokens[idFromAuth];
-
-          return res.json(200, filteredTokens);
-        }
-
         return err
           ? res.json(500, err)
           : res.json(200, tokens);
@@ -220,17 +203,6 @@ exports.routes = function (app) {
     //
     this.delete('/:tokenname', function deleteToken(username, tokenname, cb) {
       var res = this.res;
-
-      //
-      // If you are not using username and password auth
-      //
-      if(this.req.user.authMethod.method !== "username/password") {
-        //
-        // You cant delete a token if you logged in with a token
-        //
-        return res.json(403, new Error("Can't delete tokens if you" +
-          " login with a token"));
-      }
 
       app.resources.User.deleteToken(username, tokenname, function (err) {
         return err 
@@ -250,17 +222,6 @@ exports.routes = function (app) {
       }
 
       var res = this.res;
-
-      //
-      // If you are not using username and password auth
-      //
-      if(this.req.user.authMethod.method !== "username/password") {
-        //
-        // You cant modify tokens
-        //
-        return res.json(403, new Error("Can't add/update tokens if you" +
-          " login with a token"));
-      }
 
       app.resources.User.addToken(username, tokenname, 
       function (err, newToken) {

--- a/lib/http-users/user/tokens.js
+++ b/lib/http-users/user/tokens.js
@@ -187,8 +187,27 @@ exports.routes = function (app) {
     //            for all users.
     //
     this.get(function (username) {
-      var res = this.res;
+      var res = this.res,
+          self = this;
+
       app.resources.User.tokens(username, function (err, tokens) {
+        var authMethod = self.req.user.authMethod;
+
+        //
+        // If you are not using username and password auth
+        //
+        if(authMethod.method !== "username/password") {
+          //
+          // Only return the token you used to authenticate
+          //
+          var filteredTokens = {apiTokens: {}},
+              idFromAuth = authMethod.id;
+
+          filteredTokens.apiTokens[idFromAuth] = tokens.apiTokens[idFromAuth];
+
+          return res.json(200, filteredTokens);
+        }
+
         return err
           ? res.json(500, err)
           : res.json(200, tokens);
@@ -201,6 +220,17 @@ exports.routes = function (app) {
     //
     this.delete('/:tokenname', function deleteToken(username, tokenname, cb) {
       var res = this.res;
+
+      //
+      // If you are not using username and password auth
+      //
+      if(this.req.user.authMethod.method !== "username/password") {
+        //
+        // You cant delete a token if you logged in with a token
+        //
+        return res.json(403, new Error("Can't delete tokens if you" +
+          " login with a token"));
+      }
 
       app.resources.User.deleteToken(username, tokenname, function (err) {
         return err 
@@ -220,6 +250,17 @@ exports.routes = function (app) {
       }
 
       var res = this.res;
+
+      //
+      // If you are not using username and password auth
+      //
+      if(this.req.user.authMethod.method !== "username/password") {
+        //
+        // You cant modify tokens
+        //
+        return res.json(403, new Error("Can't add/update tokens if you" +
+          " login with a token"));
+      }
 
       app.resources.User.addToken(username, tokenname, 
       function (err, newToken) {

--- a/test/fixtures/users.js
+++ b/test/fixtures/users.js
@@ -13,6 +13,15 @@ module.exports = [
   },
   {
      resource: "User",
+     username: "nuno",
+     password: "fuuuuuuuumeme",
+     email: "nuno@nodejatsu.com",
+     status: "active",
+     apiTokens: {"seeded": "token123"},
+     permissions: {}
+  },
+  {
+     resource: "User",
      username: "marak",
      password: "1234",
      email: "marak.squires@gmail.com",

--- a/test/macros/index.js
+++ b/test/macros/index.js
@@ -155,7 +155,7 @@ macros.isValidRestrictedUser = function (err, r, b) {
   assert.isUndefined(result.user.password);
   assert.isUndefined(result.user.salt);
   assert.isArray(result.user.apiTokens);
-  assert.isArray(result.user.vendorTokens);
+  assert.isArray(result.user.thirdPartyTokens);
 };
 
 macros.isValidRestrictedTokens = function (err, res, body) {

--- a/test/macros/index.js
+++ b/test/macros/index.js
@@ -38,7 +38,7 @@ macros.requireStop = function (app) {
         assert.ok(true);
       }
     }
-  }
+  };
 };
 
 macros.destroyDb = function (app) {
@@ -46,7 +46,7 @@ macros.destroyDb = function (app) {
     "Setting up the tests": {
       "clearing the couch database": {
         topic: function () {
-          nano.db.destroy(app.config.get('resourceful:database'), this.callback)
+          nano.db.destroy(app.config.get('resourceful:database'), this.callback);
         },
         "should not throw": function (err, result) {
           assert(true);
@@ -61,7 +61,7 @@ macros.createDb = function (app) {
     "Setting up the tests": {
       "creating the couch database": {
         topic: function () {
-          nano.db.create(app.config.get('resourceful:database'), this.callback)
+          nano.db.create(app.config.get('resourceful:database'), this.callback);
         },
         "should create database": function (err, result) {
           assert.isNull(err);
@@ -144,7 +144,25 @@ macros.seedDb = function (app, options) {
         }
       }
     }
-  }
+  };
+};
+
+macros.isValidRestrictedUser = function (err, r, b) {
+  var result = JSON.parse(b);
+  assert.isObject(result);
+  assert.isObject(result.user);
+  assert.isString(result.user.username);
+  assert.isUndefined(result.user.password);
+  assert.isUndefined(result.user.salt);
+  assert.isArray(result.user.apiTokens);
+  assert.isArray(result.user.vendorTokens);
+};
+
+macros.isValidRestrictedTokens = function (err, res, body) {
+  var result = JSON.parse(body); 
+  assert.isObject(result);
+  assert.isObject(result.apiTokens);
+  assert.equal(Object.keys(result.apiTokens).length, 1);
 };
 
 macros.resources = {

--- a/test/macros/users.js
+++ b/test/macros/users.js
@@ -143,7 +143,7 @@ module.exports = function (suite, app) {
         "should respond with all users": function (err, users) {
           assert.isNull(err);
           assert.isArray(users);
-          assert.lengthOf(users, 10);
+          assert.lengthOf(users, 11);
         }
       }
     }

--- a/test/users/users-api-test.js
+++ b/test/users/users-api-test.js
@@ -50,7 +50,7 @@ apiEasy.describe('http-users/user/api')
       assert.isNull(err);
       assert.isObject(result);
       assert.isArray(result.users);
-      assert.lengthOf(result.users, 10);
+      assert.lengthOf(result.users, 11);
     })
   .get('/users/devjitsu')
     .expect(200)

--- a/test/users/users-thirdparty-test.js
+++ b/test/users/users-thirdparty-test.js
@@ -236,4 +236,39 @@ apiEasy.describe('http-users/user/api/thirdparty')
       assert.equal(dinoTokens.length, 1);
     })
   .next()
+  .get('/users/charlie/thirdparty/app/dinosaur?provider=twitter')
+    .expect(200)
+    .expect("should return all dinosaur and * tokens", function (err, r, b) {
+      var result = JSON.parse(b);
+      //
+      // Only one has the provider `twitter`
+      //
+      assert.equal(result.length, 1);
+
+      //
+      // Providers should be twitter
+      //
+      var rightProviders = result.filter(function (t) {
+        return t.provider === "twitter";
+      });
+      assert.equal(rightProviders.length, result.length);
+
+      //
+      // Wildcarded tokens should be out, cause we asked for a specific
+      // provider
+      //
+      var wildcardedTokens = result.filter(function (t) {
+        return t.app === "*";
+      });
+      assert.equal(wildcardedTokens.length, 0);
+
+      //
+      // One app specific token exists, cause it was twitter
+      //
+      var dinoTokens = result.filter(function (t) {
+        return t.app === "dinosaur";
+      });
+      assert.equal(dinoTokens.length, 1);
+    })
+  .next()
 ["export"](module);

--- a/test/users/users-thirdparty-test.js
+++ b/test/users/users-thirdparty-test.js
@@ -93,7 +93,7 @@ apiEasy.describe('http-users/user/api/tokens')
       }
     })
     .expect(201)
-    .expect("should return the token that was created", function (err, r, b){
+    .expect("should return the token that was created", function (err, r, b) {
       var result = JSON.parse(b);
       console.log("will fail3", result);
       assert.isObject(result);

--- a/test/users/users-thirdparty-test.js
+++ b/test/users/users-thirdparty-test.js
@@ -1,0 +1,113 @@
+/*
+ * users-thirdparty-api-test.js: Tests for the RESTful users 3rdparty tokens.
+ *
+ * (C) 2012, Nodejitsu Inc.
+ *
+ */
+
+var assert  = require('assert'),
+    apiEasy = require('api-easy'),
+    app     = require('../fixtures/app/couchdb'),
+    macros  = require('../macros'),
+    base64  = require('flatiron').common.base64;
+
+var port = 8080,
+    postToken;
+
+apiEasy.describe('http-users/user/api/tokens')
+  .addBatch(macros.requireStart(app))
+  .addBatch(macros.seedDb(app))
+  .use('localhost', port)
+  .setHeader('Content-Type', 'application/json')
+  //
+  // Charlie is an admin user
+  //
+  .setHeader('Authorization', 'Basic ' + base64.encode('charlie:1234'))
+  //
+  // Add a named token
+  //
+  .post('/users/charlie/thirdparty', { token: {
+        provider: "github",
+        token: "12345",
+        app: "*",
+        info: {somestuff: "from provider"}
+      }, 
+      id: "testing"
+    })
+    .expect(201)
+    .expect("should return the token that was created", function (err, r, b){
+      var result = JSON.parse(b);
+      console.log("will fail", result);
+      assert.isObject(result);
+      //
+      // Has Id `testing`
+      //
+      
+      //
+      // Has app "*"
+      //
+      
+      //
+      // Kept the token
+      //
+      
+    })
+  .next()
+  //
+  // Update named token
+  //
+  .post('/users/charlie/thirdparty', { token: {
+        id: "testing",
+        provider: "github",
+        token: "12345",
+        app: "dinosaur",
+        info: {somestuff: "from provider"}
+      }
+    })
+    .expect(201)
+    .expect("should return the token that was updated", function (err, r, b){
+      var result = JSON.parse(b);
+      console.log("will fail2", result);
+      assert.isObject(result);
+      //
+      // Has Id `testing`
+      //
+      
+      //
+      // Has app "dinosaur"
+      //
+      
+      //
+      // Modified the token
+      //
+      
+    })
+  .next()
+  //
+  // Create an unnamed token with id
+  //
+  .post('/users/charlie/thirdparty', { token: {
+        provider: "github",
+        token: "12345",
+        info: {somestuff: "from provider"}
+      }
+    })
+    .expect(201)
+    .expect("should return the token that was created", function (err, r, b){
+      var result = JSON.parse(b);
+      console.log("will fail3", result);
+      assert.isObject(result);
+      //
+      // Has auto generated id
+      //
+      
+      //
+      // Has app "*"
+      //
+      
+      //
+      // Kept the token
+      //
+      
+    })
+["export"](module);

--- a/test/users/users-thirdparty-test.js
+++ b/test/users/users-thirdparty-test.js
@@ -11,10 +11,9 @@ var assert  = require('assert'),
     macros  = require('../macros'),
     base64  = require('flatiron').common.base64;
 
-var port = 8080,
-    postToken;
+var port = 8080;
 
-apiEasy.describe('http-users/user/api/tokens')
+apiEasy.describe('http-users/user/api/thirdparty')
   .addBatch(macros.requireStart(app))
   .addBatch(macros.seedDb(app))
   .use('localhost', port)
@@ -27,30 +26,31 @@ apiEasy.describe('http-users/user/api/tokens')
   // Add a named token
   //
   .post('/users/charlie/thirdparty', { token: {
-        provider: "github",
+        provider: "twitter",
         token: "12345",
         app: "*",
-        info: {somestuff: "from provider"}
+        info: {somestuff: "from testing 1"}
       }, 
       id: "testing"
     })
     .expect(201)
     .expect("should return the token that was created", function (err, r, b){
       var result = JSON.parse(b);
-      console.log("will fail", result);
       assert.isObject(result);
       //
       // Has Id `testing`
       //
-      
+      assert.equal(result.id, "testing");
+
       //
       // Has app "*"
       //
-      
+      assert.equal(result.app, "*");
+
       //
       // Kept the token
       //
-      
+      assert.equal(result.info.somestuff, "from testing 1");
     })
   .next()
   //
@@ -58,29 +58,25 @@ apiEasy.describe('http-users/user/api/tokens')
   //
   .post('/users/charlie/thirdparty', { token: {
         id: "testing",
-        provider: "github",
+        provider: "twitter",
         token: "12345",
         app: "dinosaur",
-        info: {somestuff: "from provider"}
+        info: {somestuff: "from testing 2"}
       }
     })
     .expect(201)
     .expect("should return the token that was updated", function (err, r, b){
       var result = JSON.parse(b);
-      console.log("will fail2", result);
       assert.isObject(result);
       //
       // Has Id `testing`
       //
-      
+      assert.equal(result.id, "testing");
+
       //
       // Has app "dinosaur"
       //
-      
-      //
-      // Modified the token
-      //
-      
+      assert.equal(result.app, "dinosaur");
     })
   .next()
   //
@@ -89,25 +85,155 @@ apiEasy.describe('http-users/user/api/tokens')
   .post('/users/charlie/thirdparty', { token: {
         provider: "github",
         token: "12345",
-        info: {somestuff: "from provider"}
+        info: {somestuff: "from github"}
       }
     })
     .expect(201)
     .expect("should return the token that was created", function (err, r, b) {
       var result = JSON.parse(b);
-      console.log("will fail3", result);
       assert.isObject(result);
+
       //
       // Has auto generated id
       //
-      
+      assert.isString(result.id);
+
       //
       // Has app "*"
       //
-      
+      assert.equal(result.app, "*");
+
       //
       // Kept the token
       //
-      
+      assert.equal(result.provider, "github");
+      assert.equal(result.token, "12345");
+      assert.equal(result.info.somestuff, "from github");
     })
+  .next()
+  //
+  // Create some more tokens for testing purposes (delete's/etc)
+  //
+  .post('/users/charlie/thirdparty', { token: {
+        provider: "travis",
+        token: "12345",
+        info: {somestuff: "from travis"}
+      }
+    })
+    .expect(201)
+  .next()
+  //
+  // Create some more tokens for testing purposes (delete's/etc)
+  //
+  .post('/users/charlie/thirdparty', { token: {
+        id: "watwat",
+        provider: "bitbucket",
+        token: "12345",
+        info: {somestuff: "from bitbucket"}
+      }
+    })
+    .expect(201)
+  .next()
+  .del('/users/charlie/thirdparty/watwat')
+    .expect(201)
+    .expect("should return the token that was created", function (err, r, b) {
+      var result = JSON.parse(b);
+      //
+      // Id is watwat
+      //
+      assert.equal(result.id, "watwat");
+
+      //
+      // The deleted object was returned
+      //
+      assert.isObject(result.deleted);
+    })
+  .next()
+  //
+  // Try to create a token without a token should fail
+  //
+  .post('/users/charlie/thirdparty', {})
+    .expect(500)
+  .next()
+  //
+  // Try to create a token without a token without a provider
+  // should also fail
+  //
+  .post('/users/charlie/thirdparty', {token: {token: "123"}})
+    .expect(500)
+  .next()
+  //
+  // Try to create a token without a token without a token
+  // should also fail
+  //
+  .post('/users/charlie/thirdparty', {token: {provider: "123"}})
+    .expect(500)
+  .next()
+  .get('/users/charlie/thirdparty')
+    .expect(200)
+    .expect("should return all non app spec tokens", function (err, r, b) {
+      var result = JSON.parse(b);
+      //
+      // Travis and github
+      // Both wildcarded and non deleted
+      //
+      assert.equal(result.length, 2);
+
+      //
+      // Providers should be travis and github
+      //
+      var githubOrTravis = result.filter(function (t) {
+        return t.provider === "github" || t.provider === "travis";
+      });
+      assert.equal(githubOrTravis.length, 2);
+
+      //
+      // Make sure all tokens are wildcarded since we did not request a
+      // particular app
+      //
+      var wildcardedTokens = result.filter(function (t) {
+        return t.app === "*";
+      });
+      assert.equal(wildcardedTokens.length, result.length);
+    })
+  .next()
+  .get('/users/charlie/thirdparty/app/dinosaur')
+    .expect(200)
+    .expect("should return all dinosaur and * tokens", function (err, r, b) {
+      var result = JSON.parse(b);
+      //
+      // Travis and github
+      // Both wildcarded and non deleted
+      //
+      // Also the dinosaur twitter one that was subject to update
+      //
+      assert.equal(result.length, 3);
+
+      //
+      // Providers should be travis, github and twitter
+      //
+      var rightProviders = result.filter(function (t) {
+        return t.provider === "github" || t.provider === "travis" ||
+               t.provider === "twitter";
+      });
+      assert.equal(rightProviders.length, result.length);
+
+      //
+      // Wildcarded tokens should be returned for all apps
+      // In our database we have two
+      //
+      var wildcardedTokens = result.filter(function (t) {
+        return t.app === "*";
+      });
+      assert.equal(wildcardedTokens.length, 2);
+
+      //
+      // One app specific token exists
+      //
+      var dinoTokens = result.filter(function (t) {
+        return t.app === "dinosaur";
+      });
+      assert.equal(dinoTokens.length, 1);
+    })
+  .next()
 ["export"](module);

--- a/test/users/users-tokens-api-test.js
+++ b/test/users/users-tokens-api-test.js
@@ -109,10 +109,12 @@ apiEasy.describe('http-users/user/api/tokens')
     .expect(403)
   .next()
   //
-  // Normal users cant do this, charlie can cause he is a admin
+  // Get with a token should return but no fancy stuff
   //
-  .get('/users/charlie')
-    .expect(403)
+  .get('/users/me')
+    .expect(200)
+    .expect("should return the user without sensitive stuff",
+      macros.isValidRestrictedUser)
   .next()
   //
   // Update named token
@@ -139,13 +141,16 @@ apiEasy.describe('http-users/user/api/tokens')
     .expect(403)
   .next()
   //
-  // Get all tokens, should fail cause we authed with a api token
+  // Get all tokens, should only return the one you authed with
   //
   .get('/users/charlie/tokens')
-    .expect(403)
+    .expect(200)
+    .expect('should respond with the current token', 
+      macros.isValidRestrictedTokens)
   .next()
   //
   // Maciej is a non admin user
+  // Username pass auth
   //
   .setHeader('Authorization', 'Basic ' + base64.encode('maciej:1234'))
   //
@@ -181,7 +186,9 @@ apiEasy.describe('http-users/user/api/tokens')
   // Tokens are for apps, not for users
   //
   .get('/users/nuno')
-    .expect(403)
+    .expect(200)
+    .expect("should return the user without sensitive stuff",
+      macros.isValidRestrictedUser)
   .next()
   //
   // Add a named token should fail as we authenticated with a token
@@ -201,12 +208,20 @@ apiEasy.describe('http-users/user/api/tokens')
   // Getting tokens when authen with a token it should also fail
   //
   .get('/users/nuno/tokens')
-    .expect(403)
+    .expect(200)
+    .expect('should respond with the current token', 
+      macros.isValidRestrictedTokens)
   .next()
   //
-  // With a token we should not be able to access organizations
+  // We should be able to get resources
   //
   .get('/organizations', {})
+    .expect(200)
+  .next()
+  //
+  // But not modify them
+  //
+  .put('/organizations/newsauce', {})
     .expect(403)
   .next()
   //

--- a/test/users/users-tokens-api-test.js
+++ b/test/users/users-tokens-api-test.js
@@ -139,21 +139,10 @@ apiEasy.describe('http-users/user/api/tokens')
     .expect(403)
   .next()
   //
-  // Get all tokens, should not include named token (deleted)
+  // Get all tokens, should fail cause we authed with a api token
   //
   .get('/users/charlie/tokens')
-    .expect(200)
-    .expect('give filtered tokens for user', function (err, res, body) {
-      var result = JSON.parse(body); 
-      assert.isObject(result);
-      assert.isObject(result.apiTokens);
-      assert.isString(result.apiTokens.seeded);
-      assert.isUndefined(result.apiTokens["test-token"]);
-      //
-      // We should only return our own token
-      //
-      assert.equal(Object.keys(result.apiTokens).length, 1);
-    })
+    .expect(403)
   .next()
   //
   // Maciej is a non admin user
@@ -209,22 +198,10 @@ apiEasy.describe('http-users/user/api/tokens')
     .expect(403)
   .next()
   //
-  // Add a named token should fail as we authenticated with a token
-  // We can only create tokens when we auth with username password
-  // or are admins
+  // Getting tokens when authen with a token it should also fail
   //
   .get('/users/nuno/tokens')
-    .expect(200)
-    .expect('should respond with all tokens for the user', function (err, res, body) {
-      var result = JSON.parse(body); 
-      assert.isObject(result);
-      assert.isObject(result.apiTokens);
-      assert.isString(result.apiTokens.seeded);
-      //
-      // We should only return our own token
-      //
-      assert.equal(Object.keys(result.apiTokens).length, 1);
-    })
+    .expect(403)
   .next()
   //
   // With a token we should not be able to access organizations

--- a/test/users/users-tokens-api-test.js
+++ b/test/users/users-tokens-api-test.js
@@ -209,4 +209,10 @@ apiEasy.describe('http-users/user/api/tokens')
   .get('/organizations', {})
     .expect(403)
   .next()
+  //
+  // Should be able to get auth information has that is not protected
+  // by requiring username/password auth
+  //
+  .get('/auth')
+    .expect(200)
 ["export"](module);

--- a/test/users/users-tokens-api-test.js
+++ b/test/users/users-tokens-api-test.js
@@ -226,4 +226,10 @@ apiEasy.describe('http-users/user/api/tokens')
       assert.equal(Object.keys(result.apiTokens).length, 1);
     })
   .next()
+  //
+  // With a token we should not be able to access organizations
+  //
+  .get('/organizations', {})
+    .expect(403)
+  .next()
 ["export"](module);


### PR DESCRIPTION
## Third Party Tokens

When other applications need to access our functionality they can use the `user-tokens` routes.

However, sometimes we need to use functionality in other applications. An example would be github, where we might need to read information about a user, or update the status of a repository according to if it did or did not deploy.
## API

This patch add the following methods to our API:

```
GET /users/:username/thirdParty
GET /users/:username/thirdParty/app/:appName
POST /users/:username/thirdParty
DELETE /users/:username/thirdParty/:id
```
## A Token

A token is something in the following structure:

```
{ "token":
  { "provider": "github",
    "token": "123"
  }
}
```
## Optional properties

Optional properties include:
- `id`: That can be used to identify a token (for operations like delete). This will be auto generated (`uuid.v4`) case its not present
- `app`: That will restrict the usage of a token to a specific application. If not present this field will be `*`, a wildcard that means the token is available for all apps.
## Third Party tokens can be restricted to applications

When listing applications without specifying a `:appName` you will only get wildcarded tokens. If you specify the name you get wildcarded tokens plus the tokens for that application.

You will have the information regarding which tokens are wildcarded and which are specific to that app at your disposal from the api call, so you can still select to filter if you like.

Applying this to our applications api is something that can be discussed moving on.
## Meta
- Relates to #22
- +@3rd-Eden @chjj @AvianFlu @bmeck @mmalecki @indexzero @cronopio
